### PR TITLE
TASK: Configure and render documents by name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: build
+
+on:
+  push:
+      branches:
+        - 'main'
+  pull_request:
+      branches:
+        - 'main'
+
+jobs:
+    test:
+        name: "Test (PHP ${{ matrix.php-versions }}, Flow ${{ matrix.flow-versions }})"
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php-versions: ["8.2"]
+                flow-versions: ["8.3"]
+                include:
+                  - php-versions: '8.3'
+                    flow-versions: '8.3'
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  path: ${{ env.FLOW_FOLDER }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
+                  ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
+
+            - name: Set Neos Version
+              run: composer require neos/flow ^${{ matrix.flow-versions }} --no-progress --no-interaction
+
+            - name: Run Linter
+              run: composer lint
+
+            - name: Run Test
+              run: composer test

--- a/Classes/Command/OpenApiCommandController.php
+++ b/Classes/Command/OpenApiCommandController.php
@@ -11,22 +11,20 @@ use Sitegeist\SchemeOnYou\Domain\OpenApiDocumentRepository;
 #[Flow\Scope('singleton')]
 final class OpenApiCommandController extends CommandController
 {
-    #[Flow\InjectConfiguration(path: 'schemaTargetFilePath')]
-    protected string $schemaTargetFilePath;
-
     #[Flow\Inject]
     protected OpenApiDocumentRepository $documentRepository;
 
-    public function renderDocumentCommand(): void
+    /**
+     * @param string $name the name of the api document to render
+     */
+    public function documentCommand(string $name): void
     {
-        $schema = $this->documentRepository->findDocument();
-        file_put_contents(
-            /** @phpstan-ignore-next-line known constant */
-            FLOW_PATH_ROOT . $this->schemaTargetFilePath,
+        $schema = $this->documentRepository->findDocumentByName($name);
+        $this->output->output(
             \json_encode(
                 $schema,
-                JSON_THROW_ON_ERROR + JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES + JSON_UNESCAPED_UNICODE
-            )
+                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            ) . PHP_EOL
         );
     }
 }

--- a/Classes/Controller/OpenApiController.php
+++ b/Classes/Controller/OpenApiController.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sitegeist\SchemeOnYou\Controller;

--- a/Classes/Controller/OpenApiController.php
+++ b/Classes/Controller/OpenApiController.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Controller;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Mvc\View\JsonView;
+use Sitegeist\SchemeOnYou\Domain\OpenApiDocumentRepository;
+
+class OpenApiController extends ActionController
+{
+    protected $defaultViewObjectName = JsonView::class;
+
+    #[Flow\Inject]
+    protected OpenApiDocumentRepository $documentRepository;
+
+    public function documentAction(string $name): string
+    {
+        $schema = $this->documentRepository->findDocumentByName($name);
+        $this->response->setContentType('application\json');
+        return \json_encode(
+            $schema,
+            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+    }
+}

--- a/Classes/Domain/OpenApiDocumentRepository.php
+++ b/Classes/Domain/OpenApiDocumentRepository.php
@@ -52,7 +52,7 @@ final class OpenApiDocumentRepository
             // only include classes that match the $classNamePatterns
             $includeClassName = false;
             foreach ($documentClassNamePatterns as $documentClassNamePattern) {
-                if (fnmatch($documentClassNamePattern, $className, FNM_NOESCAPE)){
+                if (fnmatch($documentClassNamePattern, $className, FNM_NOESCAPE)) {
                     $includeClassName = true;
                     break;
                 }

--- a/Classes/Domain/OpenApiDocumentRepository.php
+++ b/Classes/Domain/OpenApiDocumentRepository.php
@@ -21,17 +21,46 @@ final class OpenApiDocumentRepository
     #[Flow\InjectConfiguration(path: 'rootObject')]
     protected array $rootObjectConfiguration;
 
+    /**
+     * @var array<string,array{name:string, classNames: string[]}>
+     */
+    #[Flow\InjectConfiguration(path: 'documents')]
+    protected array $documentConfiguration;
+
     public function __construct(
         private readonly ReflectionService $reflectionService
     ) {
     }
 
-    public function findDocument(): OpenApiDocument
+    public function findDocumentByName(string $name): OpenApiDocument
     {
+        if (!array_key_exists($name, $this->documentConfiguration)) {
+            throw new \InvalidArgumentException(sprintf('Api spec document "%s" is not configured', $name));
+        }
+
+        $documentName = $this->documentConfiguration[$name]['name'] ?? '';
+        $documentClassNamePatterns = $this->documentConfiguration[$name]['classNames'];
+
+        assert(is_string($documentName));
+        assert(is_array($documentClassNamePatterns));
+
         $schemaAnnotatedClassesNames = $this->reflectionService->getClassNamesByAnnotation(SchemaAttribute::class);
         $openApiControllers = $this->reflectionService->getAllSubClassNamesForClass(OpenApiController::class);
+
         $pathMethodsByClassName = [];
         foreach ($openApiControllers as $className) {
+            // only include classes that match the $classNamePatterns
+            $includeClassName = false;
+            foreach ($documentClassNamePatterns as $documentClassNamePattern) {
+                if (fnmatch($documentClassNamePattern, $className, FNM_NOESCAPE)){
+                    $includeClassName = true;
+                    break;
+                }
+            }
+            if ($includeClassName === false) {
+                continue;
+            }
+
             /** @var class-string $className */
             $pathMethods = $this->reflectionService->getMethodsAnnotatedWith($className, PathAttribute::class);
             if (!empty($pathMethods)) {

--- a/Configuration/Development/Policy.yaml
+++ b/Configuration/Development/Policy.yaml
@@ -1,0 +1,7 @@
+roles:
+  'Neos.Flow:Everybody':
+    privileges:
+      -
+        privilegeTarget: 'Sitegeist.SchemeOnYou:OpenApi'
+        permission: GRANT
+

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -1,0 +1,15 @@
+privilegeTargets:
+  'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
+    'Sitegeist.SchemeOnYou:OpenApi':
+      matcher: 'method(Sitegeist\SchemeOnYou\Controller\OpenApiController->(document)Action())'
+roles:
+  'Neos.Flow:Everybody':
+    privileges:
+      -
+        privilegeTarget: 'Sitegeist.SchemeOnYou:OpenApi'
+        permission: ABSTAIN
+  'Neos.Neos:Administrator':
+    privileges:
+      -
+        privilegeTarget: 'Sitegeist.SchemeOnYou:OpenApi'
+        permission: GRANT

--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -1,0 +1,10 @@
+##
+# Scheme On You
+-
+  name:  'Scheme On You - API Spec'
+  uriPattern: 'openapi/spec/{name}'
+  defaults:
+    '@package': 'Sitegeist.SchemeOnYou'
+    '@controller': 'OpenApi'
+    '@action': 'document'
+  httpMethods: ['GET']

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,7 +1,12 @@
+Neos:
+  Flow:
+    mvc:
+      routes:
+        Sitegeist.SchemeOnYou:
+          position: "before Neos.Neos"
+
 Sitegeist:
   SchemeOnYou:
-    # The target path where to write the schema, relative to FLOW_PATH_ROOT
-    schemaTargetFilePath: 'Web/swagger.json'
     # The OpenApi root object, see https://swagger.io/specification/#openapi-object
     rootObject:
       openapi: '3.1.0'
@@ -13,3 +18,9 @@ Sitegeist:
       security: {}
       tags: {}
       externalDocs: {}
+
+    # the seperate dictionaries that may be rendered
+    # example: {name: string, classes: [string]}
+    documents: []
+
+

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,13 @@
         }
     },
     "scripts": {
+        "fix:code-style": [
+            "phpcbf --extensions=php --colors --standard=PSR12 ./Classes",
+            "phpcbf --extensions=php --colors --standard=PSR12 ./Tests"
+        ],
+        "fix": [
+            "@fix:code-style"
+        ],
         "lint:code-style": [
             "phpcs --extensions=php --colors --standard=PSR12 ./Classes",
             "phpcs --extensions=php --colors --standard=PSR12 ./Tests"


### PR DESCRIPTION
This change adds a the configuration of the available spec documents to the setting and uses the document names as basis for rendering via cli-command  and controller.

Th cli `./flow .openapi:document __name__` will render the same spec as `openapi/specs/__name__`.

Also the setting `schemaTargetFilePath` is removed. The cli will output the spec directly to the shell where it can be sent wherever it is needed.