### PR TITLE
BUGFIX: Fix support for backedEnums and Dates as action parameters

### DIFF
--- a/Classes/Domain/OpenApiDocumentFactory.php
+++ b/Classes/Domain/OpenApiDocumentFactory.php
@@ -238,6 +238,9 @@ class OpenApiDocumentFactory
         while (count($classesToCheckStack) > 0) {
             $className = array_shift($classesToCheckStack);
             $classReflection = new ClassReflection($className);
+            if ($classReflection->isSubclassOf(\BackedEnum::class)) {
+                continue;
+            }
             $constructorReflection = $classReflection->getConstructor();
             foreach ($constructorReflection->getParameters() as $constructorParameter) {
                 $parameterType = $constructorParameter->getType();

--- a/Classes/Domain/OpenApiDocumentFactory.php
+++ b/Classes/Domain/OpenApiDocumentFactory.php
@@ -238,7 +238,8 @@ class OpenApiDocumentFactory
         while (count($classesToCheckStack) > 0) {
             $className = array_shift($classesToCheckStack);
             $classReflection = new ClassReflection($className);
-            if ($classReflection->isSubclassOf(\BackedEnum::class)) {
+            if ($classReflection->isEnum() || in_array($classReflection->getName(), [ \DateTimeImmutable::class, \DateTime::class, \DateInterval::class])) {
+                // no need to look for constructor arguments in here
                 continue;
             }
             $constructorReflection = $classReflection->getConstructor();
@@ -246,7 +247,7 @@ class OpenApiDocumentFactory
                 $parameterType = $constructorParameter->getType();
                 if ($parameterType instanceof \ReflectionNamedType) {
                     $parameterTypeName = $parameterType->getName();
-                    if (in_array($parameterTypeName, ['int', 'bool', 'string', 'float', \DateTimeImmutable::class, \DateTime::class, \DateTimeInterface::class, \DateInterval::class])) {
+                    if (in_array($parameterTypeName, ['int', 'bool', 'string', 'float', \DateTimeImmutable::class, \DateTime::class, \DateInterval::class])) {
                         continue;
                     }
                     if (in_array($parameterTypeName, $requiredSchemaClasses)) {

--- a/Classes/Domain/Path/OpenApiParameter.php
+++ b/Classes/Domain/Path/OpenApiParameter.php
@@ -77,7 +77,7 @@ final readonly class OpenApiParameter implements \JsonSerializable
             type: $parameterSchema->type,
             description: $parameterAttribute->description ?: $schemaAttribute->description,
             required: !$reflectionParameter->isDefaultValueAvailable(),
-            schema: $parameterSchema->type === 'object' ? $parameterSchema->toReference() : null,
+            schema: $parameterSchema->toReference(),
             content: $parameterAttribute->style === ParameterStyle::STYLE_DEEP_OBJECT
                 ? [
                     'application/json' => [

--- a/Classes/Domain/Schema/OpenApiSchema.php
+++ b/Classes/Domain/Schema/OpenApiSchema.php
@@ -120,6 +120,18 @@ final readonly class OpenApiSchema implements \JsonSerializable
     {
         if ($reflection->isEnum() && $reflection->isSubclassOf(\BackedEnum::class)) {
             return self::fromReflectionEnum(new \ReflectionEnum($reflection->getName()));
+        } elseif (in_array($reflection->getName(), [\DateTime::class, \DateTimeImmutable::class])) {
+            return new self(
+                name: $reflection->getName(),
+                type: 'string',
+                format: 'date-time',
+            );
+        } elseif ($reflection->getName() === \DateInterval::class) {
+            return new self(
+                name: $reflection->getName(),
+                type: 'string',
+                format: 'duration',
+            );
         } elseif (IsDataTransferObjectCollection::isSatisfiedByReflectionClass($reflection)) {
             return self::fromCollectionReflectionClass($reflection);
         } elseif (IsDataTransferObject::isSatisfiedByReflectionClass($reflection)) {

--- a/Classes/Domain/Schema/OpenApiSchema.php
+++ b/Classes/Domain/Schema/OpenApiSchema.php
@@ -118,7 +118,9 @@ final readonly class OpenApiSchema implements \JsonSerializable
      */
     public static function fromReflectionClass(\ReflectionClass $reflection): self
     {
-        if (IsDataTransferObjectCollection::isSatisfiedByReflectionClass($reflection)) {
+        if ($reflection->isEnum() && $reflection->isSubclassOf(\BackedEnum::class)) {
+            return self::fromReflectionEnum(new \ReflectionEnum($reflection->getName()));
+        } elseif (IsDataTransferObjectCollection::isSatisfiedByReflectionClass($reflection)) {
             return self::fromCollectionReflectionClass($reflection);
         } elseif (IsDataTransferObject::isSatisfiedByReflectionClass($reflection)) {
             return self::fromObjectReflectionClass($reflection);


### PR DESCRIPTION
Previously Enums and Dates as parameters were not handled correctly. Also this adds a schema reference to create a relation to the component schema for Object parameters.