### PR TITLE
TASK: Support nullable parameters

### DIFF
--- a/Classes/Application/ParameterFactory.php
+++ b/Classes/Application/ParameterFactory.php
@@ -33,9 +33,6 @@ class ParameterFactory
             if (!$type instanceof \ReflectionNamedType) {
                 throw new \DomainException('Can only resolve named parameters with single type', 1709721743);
             }
-            if ($type->allowsNull()) {
-                throw new \DomainException('Nullable types are not supported yet', 1709721755);
-            }
 
             $requestBodyAttribute = RequestBody::tryFromReflectionParameter($parameter);
             if ($requestBodyAttribute) {

--- a/Classes/Domain/Path/ParameterLocation.php
+++ b/Classes/Domain/Path/ParameterLocation.php
@@ -23,10 +23,10 @@ enum ParameterLocation: string implements \JsonSerializable
     public function resolveParameterFromRequest(ActionRequest $request, string $parameterName): array|int|bool|string|float|null
     {
         return match ($this) {
-            ParameterLocation::LOCATION_PATH => $request->getArgument($parameterName),
-            ParameterLocation::LOCATION_QUERY => $request->getHttpRequest()->getQueryParams()[$parameterName],
-            ParameterLocation::LOCATION_HEADER => $request->getHttpRequest()->getHeader($parameterName),
-            ParameterLocation::LOCATION_COOKIE => $request->getHttpRequest()->getCookieParams()[$parameterName],
+            ParameterLocation::LOCATION_PATH => $request->hasArgument($parameterName) ? $request->getArgument($parameterName) : null,
+            ParameterLocation::LOCATION_QUERY => $request->getHttpRequest()->getQueryParams()[$parameterName] ?? null,
+            ParameterLocation::LOCATION_HEADER => $request->getHttpRequest()->hasHeader($parameterName) ? $request->getHttpRequest()->getHeader($parameterName) : null,
+            ParameterLocation::LOCATION_COOKIE => $request->getHttpRequest()->getCookieParams()[$parameterName] ?? null,
         };
     }
 


### PR DESCRIPTION
Method parameters are allowed to be nullable and parameter resolution will resolve to null if the specified parameter is not set.