### PR TITLE
TASK: Handle array collection parameters gracefully by adding []

### DIFF
--- a/Classes/Domain/OpenApiDocumentFactory.php
+++ b/Classes/Domain/OpenApiDocumentFactory.php
@@ -220,6 +220,8 @@ class OpenApiDocumentFactory
                         OpenApiResponses::fromReflectionMethod($methodReflection)
                     );
                 }
+                // only the first matching route is needed so we can break the loop here
+                break;
             }
         }
 

--- a/Classes/Domain/Path/OpenApiParameter.php
+++ b/Classes/Domain/Path/OpenApiParameter.php
@@ -53,7 +53,7 @@ final readonly class OpenApiParameter implements \JsonSerializable
                 in: $parameterAttribute->in,
                 type: $parameterSchema->type,
                 format: $parameterSchema->format,
-                description: $parameterAttribute->description ?: '',
+                description: $parameterAttribute->description,
                 required: !$reflectionParameter->allowsNull(),
                 style: $parameterAttribute->style
             );

--- a/Classes/Domain/Path/OpenApiParameter.php
+++ b/Classes/Domain/Path/OpenApiParameter.php
@@ -72,7 +72,7 @@ final readonly class OpenApiParameter implements \JsonSerializable
         $parameterSchema = OpenApiSchema::fromReflectionClass($reflectionClass);
 
         return new self(
-            name: $reflectionParameter->name,
+            name: $reflectionParameter->name . (($parameterAttribute->in === ParameterLocation::LOCATION_QUERY && $parameterSchema->type === 'array') ? '[]' : ''),
             in: $parameterAttribute->in,
             type: $parameterSchema->type,
             description: $parameterAttribute->description ?: $schemaAttribute->description,

--- a/Tests/Fixtures/Controller/PathController.php
+++ b/Tests/Fixtures/Controller/PathController.php
@@ -9,6 +9,8 @@ use Sitegeist\SchemeOnYou\Domain\Metadata as OpenApi;
 use Sitegeist\SchemeOnYou\Domain\Path\ParameterLocation;
 use Sitegeist\SchemeOnYou\Domain\Path\ParameterStyle;
 use Sitegeist\SchemeOnYou\Domain\Path\RequestBodyContentType;
+use Sitegeist\SchemeOnYou\Tests\Fixtures\Identifier;
+use Sitegeist\SchemeOnYou\Tests\Fixtures\IdentifierCollection;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Path\AnotherEndpointQuery;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Path\EndpointQuery;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Path\EndpointQueryFailed;
@@ -95,5 +97,14 @@ final class PathController extends OpenApiController
         return $anotherEndpointQuery->pleaseFail
             ? new EndpointQueryFailed('Failure was requested')
             : new EndpointResponse('Hello world in language ' . $endpointQuery->language);
+    }
+
+    public function singleValueObjectsParameterEndpointAction(
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        Identifier $identifier,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        IdentifierCollection $identifierCollection,
+    ): EndpointResponse {
+        return new EndpointResponse('acknowledged');
     }
 }

--- a/Tests/Fixtures/IdentifierCollection.php
+++ b/Tests/Fixtures/IdentifierCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures;
+
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\SchemeOnYou\Domain\Metadata as OpenApi;
+
+#[Flow\Proxy(false)]
+final readonly class IdentifierCollection
+{
+    /**
+     * @var Identifier[]
+     */
+    public array $items;
+    public function __construct(
+        Identifier ...$items,
+    ) {
+        $this->items = $items;
+    }
+}

--- a/Tests/Unit/Application/ParameterFactoryTest.php
+++ b/Tests/Unit/Application/ParameterFactoryTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Sitegeist\SchemeOnYou\Application\ParameterFactory;
 use Sitegeist\SchemeOnYou\Domain\Path\HttpMethod;
+use Sitegeist\SchemeOnYou\Tests\Fixtures\Identifier;
+use Sitegeist\SchemeOnYou\Tests\Fixtures\IdentifierCollection;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Path\AnotherEndpointQuery;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Path\EndpointQuery;
 use Sitegeist\SchemeOnYou\Tests\Controller\PathController;
@@ -109,6 +111,26 @@ final class ParameterFactoryTest extends TestCase
             'expectedParameters' => [
                 'endpointQuery' => new EndpointQuery('de'),
                 'anotherEndpointQuery' => new AnotherEndpointQuery(true),
+            ]
+        ];
+
+        $collectionParametersRequest = ActionRequest::fromHttpRequest(
+            (new ServerRequest(
+                HttpMethod::METHOD_GET->value,
+                new Uri('https://acme.site/?identifierCollection[]=foo&identifierCollection[]=bar&identifier=baz')
+            ))->withQueryParams([
+                'identifierCollection' => ['foo','bar'],
+                'identifier' => 'baz'
+            ])
+        );
+
+        yield 'withSingleValueObjectsParameterEndpointAction' => [
+            'request' => $collectionParametersRequest,
+            'className' => PathController::class,
+            'methodName' => 'singleValueObjectsParameterEndpointAction',
+            'expectedParameters' => [
+                'identifierCollection' => new IdentifierCollection(new Identifier('foo'), new Identifier('bar')),
+                'identifier' => new Identifier('baz')
             ]
         ];
     }

--- a/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
+++ b/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
@@ -110,6 +110,10 @@ final class OpenApiDocumentFactoryTest extends TestCase
                     'multipleParametersAndResponsesEndpoint',
                     'my-multiple-parameters-and-responses-endpoint'
                 ),
+                $this->createMockRoute(
+                    'singleValueObjectsParameterEndpoint',
+                    'single-value-objects-parameter-endpoint'
+                ),
             ]);
 
         $mockObjectManager = $this->getMockBuilder(ObjectManager::class)
@@ -483,6 +487,41 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             )
                         )
                     ),
+                    new OpenApiPathItem(
+                        new PathDefinition('/single-value-objects-parameter-endpoint'),
+                        HttpMethod::METHOD_GET,
+                        new OpenApiParameterCollection(
+                            new OpenApiParameter(
+                                name: 'identifier',
+                                in: ParameterLocation::LOCATION_QUERY,
+                                type: 'string',
+                                required: true,
+                                description: 'see https://schema.org/identifier',
+                                schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Identifier'),
+                                style: ParameterStyle::STYLE_FORM
+                            ),
+                            new OpenApiParameter(
+                                name: 'identifierCollection[]',
+                                in: ParameterLocation::LOCATION_QUERY,
+                                type: 'array',
+                                required: true,
+                                schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_IdentifierCollection'),
+                                style: ParameterStyle::STYLE_FORM
+                            ),
+                        ),
+                        null,
+                        new OpenApiResponses(
+                            new OpenApiResponse(
+                                200,
+                                'the query was successful',
+                                [
+                                    'application/json' => [
+                                        'schema' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointResponse')
+                                    ]
+                                ]
+                            )
+                        )
+                    ),
                 ),
                 [],
                 new OpenApiComponents(
@@ -538,7 +577,19 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             required: [
                                 'pleaseFail'
                             ]
-                        )
+                        ),
+                        new OpenApiSchema(
+                            name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Identifier',
+                            type: 'string',
+                            description: 'see https://schema.org/identifier',
+                        ),
+                        new OpenApiSchema(
+                            name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_IdentifierCollection',
+                            type: 'array',
+                            items: new OpenApiReference(
+                                ref: '#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Identifier'
+                            )
+                        ),
                     ),
                 ),
                 [],


### PR DESCRIPTION
This ensures the parameter parsing in php will detect the array correctly and the default php parameter parsing will work.

In addition this ensures that only the first matching route for a method is added to the spec-document.