### PR TITLE
BUGFIX: Create correct parameter scheme

### DIFF
--- a/Classes/Domain/Path/OpenApiParameter.php
+++ b/Classes/Domain/Path/OpenApiParameter.php
@@ -24,8 +24,6 @@ final readonly class OpenApiParameter implements \JsonSerializable
     public function __construct(
         public string $name,
         public ParameterLocation $in,
-        public string $type,
-        public ?string $format = null,
         public ?string $description = null,
         ?bool $required = null,
         public OpenApiSchema|OpenApiReference|null $schema = null,
@@ -51,8 +49,7 @@ final readonly class OpenApiParameter implements \JsonSerializable
             return new self(
                 name: $reflectionParameter->name,
                 in: $parameterAttribute->in,
-                type: $parameterSchema->type,
-                format: $parameterSchema->format,
+                schema: $parameterSchema,
                 description: $parameterAttribute->description,
                 required: !$reflectionParameter->allowsNull(),
                 style: $parameterAttribute->style
@@ -74,7 +71,6 @@ final readonly class OpenApiParameter implements \JsonSerializable
         return new self(
             name: $reflectionParameter->name . (($parameterAttribute->in === ParameterLocation::LOCATION_QUERY && $parameterSchema->type === 'array') ? '[]' : ''),
             in: $parameterAttribute->in,
-            type: $parameterSchema->type,
             description: $parameterAttribute->description ?: $schemaAttribute->description,
             required: !$reflectionParameter->isDefaultValueAvailable(),
             schema: $parameterSchema->toReference(),

--- a/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
+++ b/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
@@ -194,7 +194,6 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             new OpenApiParameter(
                                 name: 'endpointQuery',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'object',
                                 description: 'the endpoint query',
                                 required: true,
                                 schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQuery'),
@@ -221,32 +220,28 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             new OpenApiParameter(
                                 name: 'name',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'string'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'number',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'integer',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'integer'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'numberWithDecimals',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'number',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'number'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'switch',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'boolean',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'boolean'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
@@ -271,58 +266,49 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             new OpenApiParameter(
                                 name: 'message',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'string'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'number',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'integer',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'integer'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'weight',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'number',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'number'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'switch',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'boolean',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'boolean'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'dateTime',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                format: 'date-time',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'string', format: 'date-time'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'dateTimeImmutable',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                format: 'date-time',
+                                schema: new OpenApiSchema(type: 'string', format: 'date-time'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'dateInterval',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                format: 'duration',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'string', format: 'duration'),
                                 required: true,
                                 style: ParameterStyle::STYLE_FORM
                             ),
@@ -347,58 +333,49 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             new OpenApiParameter(
                                 name: 'message',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'string'),
                                 required: false,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'number',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'integer',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'integer'),
                                 required: false,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'weight',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'number',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'number'),
                                 required: false,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'switch',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'boolean',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'boolean'),
                                 required: false,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'dateTime',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                format: 'date-time',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'string', format: 'date-time'),
                                 required: false,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'dateTimeImmutable',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                format: 'date-time',
+                                schema: new OpenApiSchema(type: 'string', format: 'date-time'),
                                 required: false,
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
                                 name: 'dateInterval',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
-                                format: 'duration',
-                                description: '',
+                                schema: new OpenApiSchema(type: 'string', format: 'duration'),
                                 required: false,
                                 style: ParameterStyle::STYLE_FORM
                             ),
@@ -444,7 +421,6 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             new OpenApiParameter(
                                 name: 'endpointQuery',
                                 in: ParameterLocation::LOCATION_PATH,
-                                type: 'object',
                                 description: 'the endpoint query',
                                 required: true,
                                 schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQuery'),
@@ -453,7 +429,6 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             new OpenApiParameter(
                                 name: 'anotherEndpointQuery',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'object',
                                 description: 'another endpoint query',
                                 required: true,
                                 schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_AnotherEndpointQuery'),
@@ -494,7 +469,6 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             new OpenApiParameter(
                                 name: 'identifier',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'string',
                                 required: true,
                                 description: 'see https://schema.org/identifier',
                                 schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Identifier'),
@@ -503,7 +477,6 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             new OpenApiParameter(
                                 name: 'identifierCollection[]',
                                 in: ParameterLocation::LOCATION_QUERY,
-                                type: 'array',
                                 required: true,
                                 schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_IdentifierCollection'),
                                 style: ParameterStyle::STYLE_FORM
@@ -536,7 +509,7 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 ])
                             ],
                             required: [
-                                'thing'
+                            'thing'
                             ]
                         ),
                         new OpenApiSchema(
@@ -549,7 +522,7 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 ])
                             ],
                             required: [
-                                'language'
+                            'language'
                             ]
                         ),
                         new OpenApiSchema(
@@ -562,7 +535,7 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 ])
                             ],
                             required: [
-                                'reason'
+                            'reason'
                             ]
                         ),
                         new OpenApiSchema(
@@ -575,7 +548,7 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 ])
                             ],
                             required: [
-                                'pleaseFail'
+                            'pleaseFail'
                             ]
                         ),
                         new OpenApiSchema(

--- a/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
+++ b/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
@@ -42,10 +42,10 @@ final class OpenApiSchemaTest extends TestCase
         yield 'stringEnum' => [
             'className' => DayOfWeek::class,
             'expectedDefinition' => new OpenApiSchema(
-                'Sitegeist_SchemeOnYou_Tests_Fixtures_DayOfWeek',
-                'string',
-                'see https://schema.org/DayOfWeek',
-                [
+                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_DayOfWeek',
+                type: 'string',
+                description: 'see https://schema.org/DayOfWeek',
+                enum: [
                     'https://schema.org/Monday',
                     'https://schema.org/Tuesday',
                     'https://schema.org/Wednesday',
@@ -60,10 +60,10 @@ final class OpenApiSchemaTest extends TestCase
         yield 'intEnum' => [
             'className' => ImportantNumber::class,
             'expectedDefinition' => new OpenApiSchema(
-                'Sitegeist_SchemeOnYou_Tests_Fixtures_ImportantNumber',
-                'integer',
-                'important numbers only',
-                [
+                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_ImportantNumber',
+                type: 'integer',
+                description: 'important numbers only',
+                enum: [
                     23,
                     42,
                 ],
@@ -73,27 +73,27 @@ final class OpenApiSchemaTest extends TestCase
         yield 'stringValueObject' => [
             'className' => Identifier::class,
             'expectedDefinition' => new OpenApiSchema(
-                'Sitegeist_SchemeOnYou_Tests_Fixtures_Identifier',
-                'string',
-                'see https://schema.org/identifier',
+                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Identifier',
+                type: 'string',
+                description: 'see https://schema.org/identifier',
             ),
         ];
 
         yield 'intValueObject' => [
             'className' => QuantitativeValue::class,
             'expectedDefinition' => new OpenApiSchema(
-                'Sitegeist_SchemeOnYou_Tests_Fixtures_QuantitativeValue',
-                'integer',
-                'see https://schema.org/QuantitativeValue',
+                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_QuantitativeValue',
+                type: 'integer',
+                description: 'see https://schema.org/QuantitativeValue',
             ),
         ];
 
         yield 'floatValueObject' => [
             'className' => Number::class,
             'expectedDefinition' => new OpenApiSchema(
-                'Sitegeist_SchemeOnYou_Tests_Fixtures_Number',
-                'number',
-                'see https://schema.org/Number',
+                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Number',
+                type: 'number',
+                description: 'see https://schema.org/Number',
             ),
         ];
 


### PR DESCRIPTION
The openapi parameter does not support `type` and `format` as those are properties of the `schema` for the parameter. This change adjusts that. Also the name of a scheme became optional now as simple types have a schema but not a distinct name.