### PR TITLE
TASK: Use `deepObject` for all non trivial parameters and remove `[]` from collection names

### DIFF
--- a/Classes/Domain/Metadata/Parameter.php
+++ b/Classes/Domain/Metadata/Parameter.php
@@ -30,13 +30,16 @@ final readonly class Parameter
         $parameterAttributes = $reflectionParameter->getAttributes(self::class);
         switch (count($parameterAttributes)) {
             case 0:
-                return new self(ParameterLocation::LOCATION_QUERY);
+                return new self(
+                    in: ParameterLocation::LOCATION_QUERY,
+                    style: ParameterStyle::createDefaultForParameterLocationAndReflection(ParameterLocation::LOCATION_QUERY, $reflectionParameter)
+                );
             case 1:
                 $arguments = $parameterAttributes[0]->getArguments();
 
                 return new self(
                     $arguments['in'] ?? $arguments[0],
-                    $arguments['style'] ?? $arguments[1] ?? null,
+                    $arguments['style'] ?? $arguments[1] ?? ParameterStyle::createDefaultForParameterLocationAndReflection($arguments[0], $reflectionParameter),
                     $arguments['description'] ?? $arguments[2] ?? null,
                 );
             default:

--- a/Classes/Domain/Path/OpenApiParameter.php
+++ b/Classes/Domain/Path/OpenApiParameter.php
@@ -69,7 +69,7 @@ final readonly class OpenApiParameter implements \JsonSerializable
         $parameterSchema = OpenApiSchema::fromReflectionClass($reflectionClass);
 
         return new self(
-            name: $reflectionParameter->name . (($parameterAttribute->in === ParameterLocation::LOCATION_QUERY && $parameterSchema->type === 'array') ? '[]' : ''),
+            name: $reflectionParameter->name,
             in: $parameterAttribute->in,
             description: $parameterAttribute->description ?: $schemaAttribute->description,
             required: !$reflectionParameter->isDefaultValueAvailable(),

--- a/Classes/Domain/Schema/IsDataTransferObject.php
+++ b/Classes/Domain/Schema/IsDataTransferObject.php
@@ -43,8 +43,9 @@ final class IsDataTransferObject
      */
     private static function evaluateReflectionClass(\ReflectionClass $reflectionClass): bool
     {
-        if ($reflectionClass instanceof \ReflectionEnum) {
-            return true;
+        if ($reflectionClass->isEnum()) {
+            /** @phpstan-ignore-next-line */
+            return (new \ReflectionEnum($reflectionClass->getName()))->isBacked();
         }
         if ($reflectionClass->isReadOnly() === false) {
             return false;

--- a/Tests/Fixtures/InvalidObjects/CollectionThatIsNotReadonly.php
+++ b/Tests/Fixtures/InvalidObjects/CollectionThatIsNotReadonly.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\InvalidObjects;
+
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\SchemeOnYou\Tests\Fixtures;
+
+#[Flow\Proxy(false)]
+final class CollectionThatIsNotReadonly
+{
+    /**
+     * @var Fixtures\Identifier[]
+     */
+    public array $items;
+    public function __construct(
+        Fixtures\Identifier ...$items
+    ) {
+        $this->items = $items;
+    }
+}

--- a/Tests/Fixtures/InvalidObjects/CollectionWithMoreThanOneProperty.php
+++ b/Tests/Fixtures/InvalidObjects/CollectionWithMoreThanOneProperty.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\InvalidObjects;
+
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\SchemeOnYou\Tests\Fixtures;
+
+#[Flow\Proxy(false)]
+final readonly class CollectionWithMoreThanOneProperty
+{
+    /**
+     * @var Fixtures\Identifier[]
+     */
+    public array $items;
+
+    public int $count;
+
+    public function __construct(
+        Fixtures\Identifier ...$items
+    ) {
+        $this->items = $items;
+        $this->count = count($items);
+    }
+}

--- a/Tests/Fixtures/InvalidObjects/CollectionWithTooManyConstructorArguments.php
+++ b/Tests/Fixtures/InvalidObjects/CollectionWithTooManyConstructorArguments.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\InvalidObjects;
+
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\SchemeOnYou\Tests\Fixtures;
+
+#[Flow\Proxy(false)]
+final readonly class CollectionWithTooManyConstructorArguments
+{
+    /**
+     * @var Fixtures\Identifier[]
+     */
+    public array $items;
+    public function __construct(
+        string $other,
+        Fixtures\Identifier ...$items
+    ) {
+        if ($other === 'whatever') {
+            $this->items = [...$items];
+        } else {
+            $this->items = $items;
+        }
+    }
+}

--- a/Tests/Fixtures/InvalidObjects/NonBackedEnum.php
+++ b/Tests/Fixtures/InvalidObjects/NonBackedEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\InvalidObjects;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+enum NonBackedEnum
+{
+    case Foo;
+    case Bar;
+}

--- a/Tests/Fixtures/InvalidObjects/ObjectThatHasNonPromotedConstructorArguments.php
+++ b/Tests/Fixtures/InvalidObjects/ObjectThatHasNonPromotedConstructorArguments.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\InvalidObjects;
+
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\SchemeOnYou\Domain\Metadata as OpenApi;
+
+#[Flow\Proxy(false)]
+final readonly class ObjectThatHasNonPromotedConstructorArguments
+{
+    public string $text;
+    public int $num;
+    public bool $switch;
+
+    public function __construct(
+        string $text,
+        int $num,
+        bool $switch
+    ) {
+
+        $this->text = $text;
+        $this->num = $num;
+        $this->switch = $switch;
+    }
+}

--- a/Tests/Fixtures/InvalidObjects/ObjectThatHasNotSupportedProperties.php
+++ b/Tests/Fixtures/InvalidObjects/ObjectThatHasNotSupportedProperties.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\InvalidObjects;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+final readonly class ObjectThatHasNotSupportedProperties
+{
+    public function __construct(
+        public \Psr\Http\Message\RequestInterface $text
+    ) {
+    }
+}

--- a/Tests/Fixtures/InvalidObjects/ObjectThatIsNotReadonly.php
+++ b/Tests/Fixtures/InvalidObjects/ObjectThatIsNotReadonly.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\InvalidObjects;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+final class ObjectThatIsNotReadonly
+{
+    public function __construct(
+        public string $text,
+        public int $num,
+        public bool $switch
+    ) {
+    }
+}

--- a/Tests/Unit/Application/ParameterFactoryTest.php
+++ b/Tests/Unit/Application/ParameterFactoryTest.php
@@ -57,12 +57,12 @@ final class ParameterFactoryTest extends TestCase
             'request' => ActionRequest::fromHttpRequest(
                 (new ServerRequest(
                     HttpMethod::METHOD_GET->value,
-                    new Uri('https://acme.site/?endpointQuery=de')
-                ))->withQueryParams([
-                    'endpointQuery' => [
-                        'language' => 'de'
+                    new Uri('https://acme.site/')
+                ))->withQueryParams(
+                    [
+                        'endpointQuery' => '{"language":"de"}'
                     ]
-                ])
+                )
             ),
             'className' => PathController::class,
             'methodName' => 'singleParameterAndResponseEndpointAction',
@@ -97,13 +97,14 @@ final class ParameterFactoryTest extends TestCase
         $multipleParametersRequest = ActionRequest::fromHttpRequest(
             (new ServerRequest(
                 HttpMethod::METHOD_GET->value,
-                new Uri('https://acme.site/?endpointQuery=de')
-            ))->withQueryParams([
-                'anotherEndpointQuery' => '{"pleaseFail": true}'
-            ])
+                new Uri('https://acme.site/de/')
+            ))->withQueryParams(
+                [
+                    'endpointQuery' => ['language' => 'de'],
+                    'anotherEndpointQuery' => '{"pleaseFail":"true"}'
+                ]
+            )
         );
-        $multipleParametersRequest->setArgument('endpointQuery', ['language' => 'de']);
-
         yield 'withMultipleParameters' => [
             'request' => $multipleParametersRequest,
             'className' => PathController::class,

--- a/Tests/Unit/Application/ParameterFactoryTest.php
+++ b/Tests/Unit/Application/ParameterFactoryTest.php
@@ -100,11 +100,12 @@ final class ParameterFactoryTest extends TestCase
                 new Uri('https://acme.site/de/')
             ))->withQueryParams(
                 [
-                    'endpointQuery' => ['language' => 'de'],
                     'anotherEndpointQuery' => '{"pleaseFail":"true"}'
                 ]
             )
         );
+        $multipleParametersRequest->setArgument('endpointQuery', ['language' => 'de']);
+
         yield 'withMultipleParameters' => [
             'request' => $multipleParametersRequest,
             'className' => PathController::class,
@@ -118,9 +119,9 @@ final class ParameterFactoryTest extends TestCase
         $collectionParametersRequest = ActionRequest::fromHttpRequest(
             (new ServerRequest(
                 HttpMethod::METHOD_GET->value,
-                new Uri('https://acme.site/?identifierCollection[]=foo&identifierCollection[]=bar&identifier=baz')
+                new Uri('https://acme.site/?identifierCollection=foo&identifierCollection=bar&identifier=baz')
             ))->withQueryParams([
-                'identifierCollection' => ['foo','bar'],
+                'identifierCollection' => '["foo","bar"]',
                 'identifier' => 'baz'
             ])
         );

--- a/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
+++ b/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
@@ -197,7 +197,12 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 description: 'the endpoint query',
                                 required: true,
                                 schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQuery'),
-                                style: ParameterStyle::STYLE_FORM
+                                style: ParameterStyle::STYLE_DEEP_OBJECT,
+                                content: [
+                                    'application/json' => [
+                                        'schema' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQuery'),
+                                    ]
+                                ]
                             )
                         ),
                         null,
@@ -424,7 +429,7 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 description: 'the endpoint query',
                                 required: true,
                                 schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQuery'),
-                                style: ParameterStyle::STYLE_SIMPLE
+                                style: ParameterStyle::STYLE_SIMPLE,
                             ),
                             new OpenApiParameter(
                                 name: 'anotherEndpointQuery',
@@ -476,10 +481,16 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             ),
                             new OpenApiParameter(
                                 name: 'identifierCollection[]',
+                                description: '',
                                 in: ParameterLocation::LOCATION_QUERY,
                                 required: true,
                                 schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_IdentifierCollection'),
-                                style: ParameterStyle::STYLE_FORM
+                                style: ParameterStyle::STYLE_DEEP_OBJECT,
+                                content: [
+                                    'application/json' => [
+                                        'schema' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_IdentifierCollection')
+                                    ]
+                                ]
                             ),
                         ),
                         null,

--- a/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
+++ b/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
@@ -480,7 +480,7 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 style: ParameterStyle::STYLE_FORM
                             ),
                             new OpenApiParameter(
-                                name: 'identifierCollection[]',
+                                name: 'identifierCollection',
                                 description: '',
                                 in: ParameterLocation::LOCATION_QUERY,
                                 required: true,

--- a/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
+++ b/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Unit\Domain\Schema;
+
+use PHPUnit\Framework\TestCase;
+use Sitegeist\SchemeOnYou\Domain\Schema\IsDataTransferObject;
+use Sitegeist\SchemeOnYou\Domain\Schema\IsDataTransferObjectCollection;
+use Sitegeist\SchemeOnYou\Domain\Schema\IsSingleValueDataTransferObject;
+use Sitegeist\SchemeOnYou\Domain\Schema\IsSupportedInSchema;
+use Sitegeist\SchemeOnYou\Tests\Fixtures;
+
+final class DtoSpecificationTest extends TestCase
+{
+    public static function isSupportedInDataProvider(): \Generator
+    {
+        yield Fixtures\Composition::class => [
+            'typeName' => Fixtures\Composition::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\DayOfWeek::class => [
+            'typeName' => Fixtures\DayOfWeek::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => true,
+        ];
+
+        yield Fixtures\Identifier::class => [
+            'typeName' => Fixtures\Identifier::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => true,
+        ];
+
+        yield Fixtures\IdentifierCollection::class => [
+            'typeName' => Fixtures\IdentifierCollection::class,
+            'isSupported' => true,
+            'isDTO' => false,
+            'isDTC' => true,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\ImportantNumber::class => [
+            'typeName' => Fixtures\ImportantNumber::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => true,
+        ];
+
+        yield Fixtures\Number::class => [
+            'typeName' => Fixtures\Number::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => true,
+        ];
+
+        yield Fixtures\PostalAddress::class => [
+            'typeName' => Fixtures\PostalAddress::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\PostalAddressCollection::class => [
+            'typeName' => Fixtures\PostalAddressCollection::class,
+            'isSupported' => true,
+            'isDTO' => false,
+            'isDTC' => true,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\QuantitativeValue::class => [
+            'typeName' => Fixtures\QuantitativeValue::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => true,
+        ];
+
+        yield Fixtures\WeirdThing::class => [
+            'typeName' => Fixtures\WeirdThing::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        // invalid collections
+
+        yield Fixtures\InvalidObjects\CollectionWithTooManyConstructorArguments::class => [
+            'typeName' => Fixtures\InvalidObjects\CollectionWithTooManyConstructorArguments::class,
+            'isSupported' => false,
+            'isDTO' => false,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\InvalidObjects\CollectionWithMoreThanOneProperty::class => [
+            'typeName' => Fixtures\InvalidObjects\CollectionWithMoreThanOneProperty::class,
+            'isSupported' => false,
+            'isDTO' => false,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\InvalidObjects\CollectionThatIsNotReadonly::class => [
+            'typeName' => Fixtures\InvalidObjects\CollectionThatIsNotReadonly::class,
+            'isSupported' => false,
+            'isDTO' => false,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        // invalid objects
+
+        yield Fixtures\InvalidObjects\ObjectThatIsNotReadonly::class => [
+            'typeName' => Fixtures\InvalidObjects\ObjectThatIsNotReadonly::class,
+            'isSupported' => false,
+            'isDTO' => false,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\InvalidObjects\ObjectThatHasNotSupportedProperties::class => [
+            'typeName' => Fixtures\InvalidObjects\ObjectThatHasNotSupportedProperties::class,
+            'isSupported' => false,
+            'isDTO' => false,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\InvalidObjects\ObjectThatHasNonPromotedConstructorArguments::class => [
+            'typeName' => Fixtures\InvalidObjects\ObjectThatHasNonPromotedConstructorArguments::class,
+            'isSupported' => false,
+            'isDTO' => false,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
+        yield Fixtures\InvalidObjects\NonBackedEnum::class => [
+            'typeName' => Fixtures\InvalidObjects\NonBackedEnum::class,
+            'isSupported' => false,
+            'isDTO' => false,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+    }
+
+    /**
+     * @dataProvider isSupportedInDataProvider
+     * @param class-string $className
+     */
+    public function testIsSupportedIn(string $className, bool $isSupported, bool $isDTO, bool $isDTC, bool $isSVDTO): void
+    {
+        $this->assertEquals($isSupported, IsSupportedInSchema::isSatisfiedByClassName($className), sprintf('IsSupportedInSchema should return "%s" for class "%s"', $isSupported ? 'true' : 'false', $className));
+        $this->assertEquals($isDTO, IsDataTransferObject::isSatisfiedByClassName($className), sprintf('IsDataTransferObject should return "%s" for class "%s"', $isSupported ? 'true' : 'false', $className));
+        $this->assertEquals($isDTC, IsDataTransferObjectCollection::isSatisfiedByClassName($className), sprintf('IsDataTransferObjectCollection should return "%s" for class "%s"', $isSupported ? 'true' : 'false', $className));
+        $this->assertEquals($isSVDTO, IsSingleValueDataTransferObject::isSatisfiedByClassName($className), sprintf('IsSingleValueDataTransferObject should return "%s" for class "%s"', $isSupported ? 'true' : 'false', $className));
+    }
+
+    public function testFoo(): void
+    {
+        $this->assertEquals(false, IsDataTransferObject::isSatisfiedByClassName(Fixtures\InvalidObjects\NonBackedEnum::class));
+    }
+}

--- a/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
+++ b/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
@@ -167,9 +167,4 @@ final class DtoSpecificationTest extends TestCase
         $this->assertEquals($isDTC, IsDataTransferObjectCollection::isSatisfiedByClassName($className), sprintf('IsDataTransferObjectCollection should return "%s" for class "%s"', $isSupported ? 'true' : 'false', $className));
         $this->assertEquals($isSVDTO, IsSingleValueDataTransferObject::isSatisfiedByClassName($className), sprintf('IsSingleValueDataTransferObject should return "%s" for class "%s"', $isSupported ? 'true' : 'false', $className));
     }
-
-    public function testFoo(): void
-    {
-        $this->assertEquals(false, IsDataTransferObject::isSatisfiedByClassName(Fixtures\InvalidObjects\NonBackedEnum::class));
-    }
 }


### PR DESCRIPTION
Use style deepObject for all QueryParameters that are not scalar or singleValueValueObjects. 

also: 
- added tests for the ValueObjectSpecifications
- improved the ValueObjectSpecifications