### PR TITLE
TASK: Handle non `null` default values correctly

### DIFF
--- a/Classes/Application/ParameterFactory.php
+++ b/Classes/Application/ParameterFactory.php
@@ -44,7 +44,9 @@ class ParameterFactory
                 $parameterValueFromRequest = $parameterAttribute->style->decodeParameterValue($parameterValueFromRequest);
             }
 
-            $parameters[$parameter->name] = SchemaDenormalizer::denormalizeValue($parameterValueFromRequest, $type->getName(), $parameter);
+            if ($parameterValueFromRequest !== null || $parameter->isDefaultValueAvailable() === false) {
+                $parameters[$parameter->name] = SchemaDenormalizer::denormalizeValue($parameterValueFromRequest, $type->getName(), $parameter);
+            }
         }
 
         return $parameters;

--- a/Classes/Domain/Path/NoSuchParameter.php
+++ b/Classes/Domain/Path/NoSuchParameter.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Domain\Path;
+
+class NoSuchParameter
+{
+}

--- a/Classes/Domain/Path/ParameterLocation.php
+++ b/Classes/Domain/Path/ParameterLocation.php
@@ -18,15 +18,15 @@ enum ParameterLocation: string implements \JsonSerializable
 
     /**
      * @todo really?
-     * @return array<mixed>|int|bool|string|float|null
+     * @return NoSuchParameter|array<mixed>|int|bool|string|float|null
      */
-    public function resolveParameterFromRequest(ActionRequest $request, string $parameterName): array|int|bool|string|float|null
+    public function resolveParameterFromRequest(ActionRequest $request, string $parameterName): NoSuchParameter|array|int|bool|string|float|null
     {
         return match ($this) {
-            ParameterLocation::LOCATION_PATH => $request->hasArgument($parameterName) ? $request->getArgument($parameterName) : null,
-            ParameterLocation::LOCATION_QUERY => $request->getHttpRequest()->getQueryParams()[$parameterName] ?? null,
-            ParameterLocation::LOCATION_HEADER => $request->getHttpRequest()->hasHeader($parameterName) ? $request->getHttpRequest()->getHeader($parameterName) : null,
-            ParameterLocation::LOCATION_COOKIE => $request->getHttpRequest()->getCookieParams()[$parameterName] ?? null,
+            ParameterLocation::LOCATION_PATH => $request->hasArgument($parameterName) ? $request->getArgument($parameterName) : new NoSuchParameter(),
+            ParameterLocation::LOCATION_QUERY => array_key_exists($parameterName, $request->getHttpRequest()->getQueryParams()) ? $request->getHttpRequest()->getQueryParams()[$parameterName] : new NoSuchParameter(),
+            ParameterLocation::LOCATION_HEADER => $request->getHttpRequest()->hasHeader($parameterName) ? $request->getHttpRequest()->getHeader($parameterName) : new NoSuchParameter(),
+            ParameterLocation::LOCATION_COOKIE => $request->getHttpRequest()->getCookieParams()[$parameterName] ?? new NoSuchParameter(),
         };
     }
 

--- a/Classes/Domain/Path/RequestBodyContentType.php
+++ b/Classes/Domain/Path/RequestBodyContentType.php
@@ -13,13 +13,13 @@ enum RequestBodyContentType: string implements \JsonSerializable
 
     /**
      * @todo really?
-     * @return array<mixed>|int|bool|string|float|null
+     * @return NoSuchParameter|array<mixed>|int|bool|string|float|null
      */
-    public function resolveParameterFromRequest(ActionRequest $request, string $parameterName): array|int|bool|string|float|null
+    public function resolveParameterFromRequest(ActionRequest $request, string $parameterName): NoSuchParameter|array|int|bool|string|float|null
     {
         return match ($this) {
             RequestBodyContentType::CONTENT_TYPE_JSON => (string)$request->getHttpRequest()->getBody(),
-            RequestBodyContentType::CONTENT_TYPE_FORM => $request->getArgument($parameterName)
+            RequestBodyContentType::CONTENT_TYPE_FORM => $request->hasArgument($parameterName) ? $request->getArgument($parameterName) : new NoSuchParameter()
         };
     }
 

--- a/Tests/Fixtures/Controller/PathController.php
+++ b/Tests/Fixtures/Controller/PathController.php
@@ -81,6 +81,25 @@ final class PathController extends OpenApiController
         return new EndpointResponse('acknowledged');
     }
 
+    public function scalarNullableParameterWithoutDefaultEndpointAction(
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        ?string $message,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        ?int $number,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        ?float $weight,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        ?bool $switch,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        ?\DateTime $dateTime,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        ?\DateTime $dateTimeImmutable,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        ?\DateInterval $dateInterval,
+    ): EndpointResponse {
+        return new EndpointResponse('acknowledged');
+    }
+
     public function scalarParameterWithDefaultValuesAction(
         #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
         string $message = "suppe",

--- a/Tests/Fixtures/Controller/PathController.php
+++ b/Tests/Fixtures/Controller/PathController.php
@@ -81,6 +81,19 @@ final class PathController extends OpenApiController
         return new EndpointResponse('acknowledged');
     }
 
+    public function scalarParameterWithDefaultValuesAction(
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        string $message = "suppe",
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        int $number = 42,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        float $weight = 666,
+        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
+        bool $switch = false,
+    ): EndpointResponse {
+        return new EndpointResponse('acknowledged');
+    }
+
     public function requestBodyAndSingleResponseEndpointAction(
         #[OpenApi\RequestBody(RequestBodyContentType::CONTENT_TYPE_JSON)]
         EndpointQuery $endpointQuery

--- a/Tests/Fixtures/Controller/PathController.php
+++ b/Tests/Fixtures/Controller/PathController.php
@@ -81,38 +81,6 @@ final class PathController extends OpenApiController
         return new EndpointResponse('acknowledged');
     }
 
-    public function scalarNullableParameterWithoutDefaultEndpointAction(
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        ?string $message,
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        ?int $number,
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        ?float $weight,
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        ?bool $switch,
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        ?\DateTime $dateTime,
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        ?\DateTime $dateTimeImmutable,
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        ?\DateInterval $dateInterval,
-    ): EndpointResponse {
-        return new EndpointResponse('acknowledged');
-    }
-
-    public function scalarParameterWithDefaultValuesAction(
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        string $message = "suppe",
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        int $number = 42,
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        float $weight = 666,
-        #[OpenApi\Parameter(ParameterLocation::LOCATION_QUERY)]
-        bool $switch = false,
-    ): EndpointResponse {
-        return new EndpointResponse('acknowledged');
-    }
-
     public function requestBodyAndSingleResponseEndpointAction(
         #[OpenApi\RequestBody(RequestBodyContentType::CONTENT_TYPE_JSON)]
         EndpointQuery $endpointQuery

--- a/Tests/Unit/Application/ParameterFactoryTest.php
+++ b/Tests/Unit/Application/ParameterFactoryTest.php
@@ -94,7 +94,7 @@ final class ParameterFactoryTest extends TestCase
             ]
         ];
 
-        yield 'withScalarNullableParameters' => [
+        yield 'withScalarNullableParametersNoQueryArguments' => [
             'request' => ActionRequest::fromHttpRequest(
                 (new ServerRequest(
                     HttpMethod::METHOD_GET->value,
@@ -107,15 +107,23 @@ final class ParameterFactoryTest extends TestCase
             ]
         ];
 
-        yield 'withScalarNullableNoDefaultParameters' => [
+        yield 'withScalarNullableParametersNullPassed' => [
             'request' => ActionRequest::fromHttpRequest(
                 (new ServerRequest(
                     HttpMethod::METHOD_GET->value,
                     new Uri('https://acme.site/')
-                ))->withQueryParams([])
+                ))->withQueryParams([
+                    'message' => null,
+                    'number' => null,
+                    'weight' => null,
+                    'switch' => null,
+                    'dateTime' => null,
+                    'dateTimeImmutable' => null,
+                    'dateInterval' => null
+                ])
             ),
             'className' => PathController::class,
-            'methodName' => 'scalarNullableParameterWithoutDefaultEndpointAction',
+            'methodName' => 'scalarNullableParameterEndpointAction',
             'expectedParameters' => [
                 'message' => null,
                 'number' => null,
@@ -127,16 +135,32 @@ final class ParameterFactoryTest extends TestCase
             ]
         ];
 
-        yield 'withScalarParametersAndDefaultValues' => [
+        yield 'withScalarNullableParametersValuePassed' => [
             'request' => ActionRequest::fromHttpRequest(
                 (new ServerRequest(
                     HttpMethod::METHOD_GET->value,
                     new Uri('https://acme.site/')
-                ))->withQueryParams([])
+                ))->withQueryParams([
+                    'message' => 'aaa',
+                    'number' => 123,
+                    'weight' => 456.0,
+                    'switch' => 1,
+                    'dateTime' => '2005-08-15T15:52:01+00:00',
+                    'dateTimeImmutable' => '2005-08-15T15:52:01+00:00',
+                    'dateInterval' => 'P7D'
+                ])
             ),
             'className' => PathController::class,
-            'methodName' => 'scalarParameterWithDefaultValuesAction',
-            'expectedParameters' => []
+            'methodName' => 'scalarNullableParameterEndpointAction',
+            'expectedParameters' => [
+                'message' => 'aaa',
+                'number' => 123,
+                'weight' => 456.0,
+                'switch' => true,
+                'dateTime' => \DateTime::createFromFormat(\DateTime::ATOM, '2005-08-15T15:52:01+00:00'),
+                'dateTimeImmutable' => \DateTimeImmutable::createFromFormat(\DateTime::ATOM, '2005-08-15T15:52:01+00:00'),
+                'dateInterval' => new \DateInterval("P7D")
+            ]
         ];
 
         $multipleParametersRequest = ActionRequest::fromHttpRequest(

--- a/Tests/Unit/Application/ParameterFactoryTest.php
+++ b/Tests/Unit/Application/ParameterFactoryTest.php
@@ -94,6 +94,43 @@ final class ParameterFactoryTest extends TestCase
             ]
         ];
 
+        yield 'withScalarNullableParameters' => [
+            'request' => ActionRequest::fromHttpRequest(
+                (new ServerRequest(
+                    HttpMethod::METHOD_GET->value,
+                    new Uri('https://acme.site/')
+                ))->withQueryParams([])
+            ),
+            'className' => PathController::class,
+            'methodName' => 'scalarNullableParameterEndpointAction',
+            'expectedParameters' => [
+                'message' => null,
+                'number' => null,
+                'weight' => null,
+                'switch' => null,
+                'dateTime' => null,
+                'dateTimeImmutable' => null,
+                'dateInterval' => null
+            ]
+        ];
+
+        yield 'withScalarParametersAndDefaultValues' => [
+            'request' => ActionRequest::fromHttpRequest(
+                (new ServerRequest(
+                    HttpMethod::METHOD_GET->value,
+                    new Uri('https://acme.site/')
+                ))->withQueryParams([])
+            ),
+            'className' => PathController::class,
+            'methodName' => 'scalarParameterWithDefaultValuesAction',
+            'expectedParameters' => [
+                'message' => 'suppe',
+                'number' => 42,
+                'weight' => 666,
+                'switch' => false,
+            ]
+        ];
+
         $multipleParametersRequest = ActionRequest::fromHttpRequest(
             (new ServerRequest(
                 HttpMethod::METHOD_GET->value,

--- a/Tests/Unit/Application/ParameterFactoryTest.php
+++ b/Tests/Unit/Application/ParameterFactoryTest.php
@@ -104,6 +104,19 @@ final class ParameterFactoryTest extends TestCase
             'className' => PathController::class,
             'methodName' => 'scalarNullableParameterEndpointAction',
             'expectedParameters' => [
+            ]
+        ];
+
+        yield 'withScalarNullableNoDefaultParameters' => [
+            'request' => ActionRequest::fromHttpRequest(
+                (new ServerRequest(
+                    HttpMethod::METHOD_GET->value,
+                    new Uri('https://acme.site/')
+                ))->withQueryParams([])
+            ),
+            'className' => PathController::class,
+            'methodName' => 'scalarNullableParameterWithoutDefaultEndpointAction',
+            'expectedParameters' => [
                 'message' => null,
                 'number' => null,
                 'weight' => null,
@@ -123,12 +136,7 @@ final class ParameterFactoryTest extends TestCase
             ),
             'className' => PathController::class,
             'methodName' => 'scalarParameterWithDefaultValuesAction',
-            'expectedParameters' => [
-                'message' => 'suppe',
-                'number' => 42,
-                'weight' => 666,
-                'switch' => false,
-            ]
+            'expectedParameters' => []
         ];
 
         $multipleParametersRequest = ActionRequest::fromHttpRequest(


### PR DESCRIPTION
Internally the `resolveParameterFromRequest` method in the `RequestBody` and the `ParameterLocation` got an  additional return type `NoSuchParameter` indicating that no values was passed. 

If the `NoSuchParameter` value is detected parameter decoding is skipped and no named parameter is added to the method call allowing either defaults to take effect or raise proper missing argument Exceptions.

Fixes: #19 