### PR TITLE
BUGFIX: Fix optional parameter handling in deserializer

### DIFF
--- a/Classes/Domain/Schema/SchemaDenormalizer.php
+++ b/Classes/Domain/Schema/SchemaDenormalizer.php
@@ -88,7 +88,8 @@ class SchemaDenormalizer
         $parameterReflections = $reflection->getConstructor()->getParameters();
         $convertedArguments = [];
         if (is_array($value)) {
-            foreach ($parameterReflections as $name => $reflectionParameter) {
+            foreach ($parameterReflections as $reflectionParameter) {
+                $name = $reflectionParameter->getName();
                 $type = $reflectionParameter->getType();
                 if ($reflectionParameter->isDefaultValueAvailable() && !array_key_exists($reflectionParameter->getName(), $value)) {
                     continue;

--- a/Tests/Unit/Domain/Schema/SchemaNormalizerTest.php
+++ b/Tests/Unit/Domain/Schema/SchemaNormalizerTest.php
@@ -22,7 +22,7 @@ final class SchemaNormalizerTest extends TestCase
         ];
         yield 'PostalAddress with missing parameter in between' => [
             Fixtures\PostalAddress::class,
-            ['streetAddress' => 'Dämonenweg 23', 'addressRegion' => 'Hölle', 'postOfficeBoxNumber' => 666],
+            ['streetAddress' => 'Dämonenweg 23', 'addressRegion' => 'Hölle', 'postOfficeBoxNumber' => '666'],
             new Fixtures\PostalAddress(streetAddress: 'Dämonenweg 23', addressRegion: 'Hölle', postOfficeBoxNumber: '666')
         ];
     }

--- a/Tests/Unit/Domain/Schema/SchemaNormalizerTest.php
+++ b/Tests/Unit/Domain/Schema/SchemaNormalizerTest.php
@@ -13,6 +13,30 @@ use Sitegeist\SchemeOnYou\Tests\Fixtures\Date;
 
 final class SchemaNormalizerTest extends TestCase
 {
+    public static function denormalizeObjectsWithOptionalParametersDataProvider(): \Generator
+    {
+        yield 'min PostalAddress' => [
+            Fixtures\PostalAddress::class,
+            ['streetAddress' => 'Sesamstraße 42', 'addressRegion' => 'Muppetingen'],
+            new Fixtures\PostalAddress(streetAddress: 'Sesamstraße 42', addressRegion: 'Muppetingen')
+        ];
+        yield 'PostalAddress with missing parameter in between' => [
+            Fixtures\PostalAddress::class,
+            ['streetAddress' => 'Dämonenweg 23', 'addressRegion' => 'Hölle', 'postOfficeBoxNumber' => 666],
+            new Fixtures\PostalAddress(streetAddress: 'Dämonenweg 23', addressRegion: 'Hölle', postOfficeBoxNumber: '666')
+        ];
+    }
+
+    /**
+     * @dataProvider denormalizeObjectsWithOptionalParametersDataProvider
+     * @test
+     */
+    public function denormalizeObjectsWithOptionalParameters(mixed $type, mixed $data, mixed $expected): void
+    {
+        Assert::assertEquals($expected, SchemaDenormalizer::denormalizeValue($data, $type));
+    }
+
+
     /**
      * @dataProvider valueNormalizationPairs
      * @test


### PR DESCRIPTION
The schema denormalizer passed arguments by order and not by name which caused problems when an optional parameter in between was missing.

The fix adjusts the denormalizer to pass arguments by name to value objects