### PR TITLE
BUGFIX: The style `deepObject` together with a json payload confuses some generators and the swagger ui at times

### DIFF
--- a/Classes/Domain/Path/OpenApiParameter.php
+++ b/Classes/Domain/Path/OpenApiParameter.php
@@ -73,15 +73,22 @@ final readonly class OpenApiParameter implements \JsonSerializable
             in: $parameterAttribute->in,
             description: $parameterAttribute->description ?: $schemaAttribute->description,
             required: !$reflectionParameter->isDefaultValueAvailable(),
-            schema: $parameterSchema->toReference(),
-            content: $parameterAttribute->style === ParameterStyle::STYLE_DEEP_OBJECT
-                ? [
+            schema: match ($parameterAttribute->style) {
+                ParameterStyle::STYLE_X_JSON => null,
+                default => $parameterSchema->toReference()
+            },
+            content: match ($parameterAttribute->style) {
+                ParameterStyle::STYLE_DEEP_OBJECT, ParameterStyle::STYLE_X_JSON => [
                     'application/json' => [
                         'schema' => $parameterSchema->toReference()
                     ]
-                ]
-                : null,
-            style: $parameterAttribute->style
+                ],
+                default => null
+            },
+            style: match ($parameterAttribute->style) {
+                ParameterStyle::STYLE_X_JSON => null,
+                default => $parameterAttribute->style
+            },
         );
     }
 

--- a/Classes/Domain/Path/ParameterStyle.php
+++ b/Classes/Domain/Path/ParameterStyle.php
@@ -20,6 +20,8 @@ enum ParameterStyle: string implements \JsonSerializable
     case STYLE_PIPE_DELIMITED = 'pipeDelimited';
     case STYLE_DEEP_OBJECT = 'deepObject';
 
+    case STYLE_X_JSON = 'x-json';
+
     /**
      * @see https://swagger.io/specification/#fixed-fields-10
      */
@@ -72,7 +74,7 @@ enum ParameterStyle: string implements \JsonSerializable
             return ParameterStyle::STYLE_FORM;
         }
 
-        return  ParameterStyle::STYLE_DEEP_OBJECT;
+        return  ParameterStyle::STYLE_X_JSON;
     }
 
     /**
@@ -83,7 +85,7 @@ enum ParameterStyle: string implements \JsonSerializable
     public function decodeParameterValue(array|int|bool|string|float|null $parameterValue): array|int|bool|string|float|null
     {
         return match ($this) {
-            self::STYLE_DEEP_OBJECT => match (true) {
+            self::STYLE_DEEP_OBJECT, self::STYLE_X_JSON => match (true) {
                 $parameterValue === null => $parameterValue,
                 is_string($parameterValue) => \json_decode($parameterValue, true, 512, JSON_THROW_ON_ERROR),
                 default => throw new \DomainException('Parameters with deepObject style must be sent as JSON or null')

--- a/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
+++ b/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
@@ -196,8 +196,6 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 in: ParameterLocation::LOCATION_QUERY,
                                 description: 'the endpoint query',
                                 required: true,
-                                schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQuery'),
-                                style: ParameterStyle::STYLE_DEEP_OBJECT,
                                 content: [
                                     'application/json' => [
                                         'schema' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQuery'),
@@ -436,12 +434,12 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 in: ParameterLocation::LOCATION_QUERY,
                                 description: 'another endpoint query',
                                 required: true,
-                                schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_AnotherEndpointQuery'),
                                 content: [
                                     'application/json' => [
                                         'schema' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_AnotherEndpointQuery')
                                     ]
                                 ],
+                                schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Path_AnotherEndpointQuery'),
                                 style: ParameterStyle::STYLE_DEEP_OBJECT
                             )
                         ),
@@ -484,8 +482,6 @@ final class OpenApiDocumentFactoryTest extends TestCase
                                 description: '',
                                 in: ParameterLocation::LOCATION_QUERY,
                                 required: true,
-                                schema: new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_IdentifierCollection'),
-                                style: ParameterStyle::STYLE_DEEP_OBJECT,
                                 content: [
                                     'application/json' => [
                                         'schema' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_IdentifierCollection')


### PR DESCRIPTION
Since the deepObject style is not properly defined this change introduces a custom `x-json` style. This will not render the `schema` and `style` definitions and specify the payload via `content.application/json.$ref` which is at least sufficient for the swagger ui.

see: https://swagger.io/docs/specification/describing-parameters/#schema-vs-content