### PR TITLE
BUGFIX: Detect routes with LOCATION_PATH parameters

### DIFF
--- a/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
+++ b/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
@@ -108,7 +108,7 @@ final class OpenApiDocumentFactoryTest extends TestCase
                 ),
                 $this->createMockRoute(
                     'multipleParametersAndResponsesEndpoint',
-                    'my-multiple-parameters-and-responses-endpoint'
+                    'my-multiple-parameters-and-responses-endpoint/{endpointQuery}'
                 ),
                 $this->createMockRoute(
                     'singleValueObjectsParameterEndpoint',
@@ -420,7 +420,7 @@ final class OpenApiDocumentFactoryTest extends TestCase
                         )
                     ),
                     new OpenApiPathItem(
-                        new PathDefinition('/my-multiple-parameters-and-responses-endpoint'),
+                        new PathDefinition('/my-multiple-parameters-and-responses-endpoint/{endpointQuery}'),
                         HttpMethod::METHOD_GET,
                         new OpenApiParameterCollection(
                             new OpenApiParameter(


### PR DESCRIPTION
Previously routes with path parameters were not detected. Now parameters with LOCATION_PATH are passed to the router with a dummy value when the routes are probed.

Alongside this addresses two minor issues:
- only the first route that matched was returned as path. Now all routes are checked to create a full spec file.
- the code that ensured that only a single BODY parameter existed looked into parameter attributes aswell for seemingly no reason (i assume a copy paste error)

resolves: #29