### PR TITLE
BUGFIX: Denormalize RFC3339_EXTENDED the same way as RFC_3339

### DIFF
--- a/Classes/Domain/Schema/SchemaDenormalizer.php
+++ b/Classes/Domain/Schema/SchemaDenormalizer.php
@@ -114,14 +114,20 @@ class SchemaDenormalizer
     protected static function convertDateTime(array|float|bool|int|string $value, ?\ReflectionParameter $reflectionParameter = null): \DateTime
     {
         $propertyAttribute = $reflectionParameter ? StringProperty::tryFromReflectionParameter($reflectionParameter) : null;
-        $format = match ($propertyAttribute?->format) {
-            StringProperty::FORMAT_DATE => 'Y-m-d',
-            default => \DateTimeInterface::RFC3339
+        $formats = match ($propertyAttribute?->format) {
+            StringProperty::FORMAT_DATE => ['Y-m-d'],
+            default =>  [\DateTimeInterface::RFC3339, \DateTimeInterface::RFC3339_EXTENDED]
         };
-        $converted = match (true) {
-            is_string($value) => \DateTime::createFromFormat($format, $value),
-            default => false,
-        };
+        if (is_string($value)) {
+            foreach ($formats as $format) {
+                $converted = \DateTime::createFromFormat($format, $value);
+                if ($converted instanceof \DateTime) {
+                    break;
+                }
+            }
+        } else {
+            $converted = false;
+        }
         if ($converted === false) {
             throw new \DomainException('Can only denormalize \DateTime from an RFC 3339 string');
         }
@@ -137,14 +143,20 @@ class SchemaDenormalizer
     protected static function convertDateTimeImmutable(array|float|bool|int|string $value, ?\ReflectionParameter $reflectionParameter = null): \DateTimeImmutable
     {
         $propertyAttribute = $reflectionParameter ? StringProperty::tryFromReflectionParameter($reflectionParameter) : null;
-        $format = match ($propertyAttribute?->format) {
-            StringProperty::FORMAT_DATE => 'Y-m-d',
-            default => \DateTimeInterface::RFC3339
+        $formats = match ($propertyAttribute?->format) {
+            StringProperty::FORMAT_DATE => ['Y-m-d'],
+            default => [\DateTimeInterface::RFC3339, \DateTimeInterface::RFC3339_EXTENDED]
         };
-        $converted = match (true) {
-            is_string($value) => \DateTimeImmutable::createFromFormat($format, $value),
-            default => false,
-        };
+        if (is_string($value)) {
+            foreach ($formats as $format) {
+                $converted = \DateTimeImmutable::createFromFormat($format, $value);
+                if ($converted instanceof \DateTimeImmutable) {
+                    break;
+                }
+            }
+        } else {
+            $converted = false;
+        }
         if ($converted === false) {
             throw new \DomainException('Can only denormalize \DateTimeImmutable from an RFC 3339 string');
         }

--- a/Tests/Unit/Domain/Schema/SchemaNormalizerTest.php
+++ b/Tests/Unit/Domain/Schema/SchemaNormalizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sitegeist\SchemeOnYou\Tests\Unit\Domain\Schema;
 
+use Neos\Flow\Reflection\ParameterReflection;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Sitegeist\SchemeOnYou\Domain\Schema\SchemaDenormalizer;
@@ -240,5 +241,46 @@ final class SchemaNormalizerTest extends TestCase
                 'expirationDate' => '2010-01-28',
             ]
         ];
+    }
+
+    public static function dateNormalizationAndDenormalizationDateProvider(): \Generator
+    {
+        yield "default" => [
+            '2010-01-28T15:00:00+02:00',
+            '2010-01-28T15:00:00+02:00',
+            '2010-01-28T15:00:00+02:00'
+        ];
+        yield "with microseconds" => [
+            '2025-07-08T09:37:07.937+02:00',
+            '2025-07-08T09:37:07.937+02:00',
+            '2025-07-08T09:37:07+02:00'
+        ];
+    }
+
+    /**
+     * @dataProvider dateNormalizationAndDenormalizationDateProvider
+     * @test
+     */
+    public function dateTimeImmutableNormalizationAndDenormalization(string $normalized, string $denormalized, string $renormalized): void
+    {
+        $expectedDate = new \DateTimeImmutable($denormalized);
+        $denormalizedDate = SchemaDenormalizer::denormalizeValue($normalized, \DateTimeImmutable::class);
+        $renormalizedDate = SchemaNormalizer::normalizeValue($denormalizedDate);
+        Assert::assertEquals($expectedDate, $denormalizedDate);
+        Assert::assertEquals($renormalized, $renormalizedDate);
+    }
+
+    /**
+     * @dataProvider dateNormalizationAndDenormalizationDateProvider
+     * @test
+     */
+    public function dateTimeNormalizationAndDenormalization(string $normalized, string $denormalized, string $renormalized): void
+    {
+
+        $expectedDate = new \DateTime($denormalized);
+        $denormalizedDate = SchemaDenormalizer::denormalizeValue($normalized, \DateTime::class);
+        $renormalizedDate = SchemaNormalizer::normalizeValue($denormalizedDate);
+        Assert::assertEquals($expectedDate, $denormalizedDate);
+        Assert::assertEquals($renormalized, $renormalizedDate);
     }
 }


### PR DESCRIPTION
This is needed as openApi refers to the default format in rfc which has optional microseconds