### PR TITLE
FEATURE: Allow to configure the rootObject for each document 

### DIFF
--- a/Classes/Domain/OpenApiDocument.php
+++ b/Classes/Domain/OpenApiDocument.php
@@ -50,7 +50,16 @@ final readonly class OpenApiDocument implements \JsonSerializable
             $paths ?: new OpenApiPathCollection(),
             $configuration['webhooks'],
             $components ?: new OpenApiComponents(
-                new OpenApiSchemaCollection()
+                new OpenApiSchemaCollection(),
+                $configuration['components']['responses'] ?? [],
+                $configuration['components']['parameters'] ?? [],
+                $configuration['components']['examples'] ?? [],
+                $configuration['components']['requestBodies'] ?? [],
+                $configuration['components']['headers'] ?? [],
+                $configuration['components']['securitySchemes'] ?? [],
+                $configuration['components']['links'] ?? [],
+                $configuration['components']['callbacks'] ?? [],
+                $configuration['components']['pathItems'] ?? []
             ),
             $configuration['security'],
             $configuration['tags'],

--- a/Classes/Domain/OpenApiDocumentFactory.php
+++ b/Classes/Domain/OpenApiDocumentFactory.php
@@ -118,7 +118,16 @@ class OpenApiDocumentFactory
             $rootObjectConfiguration,
             $paths,
             new OpenApiComponents(
-                OpenApiSchemaCollection::fromClassNames($requiredSchemaClasses)
+                OpenApiSchemaCollection::fromClassNames($requiredSchemaClasses),
+                $rootObjectConfiguration['components']['responses'] ?? [],
+                $rootObjectConfiguration['components']['parameters'] ?? [],
+                $rootObjectConfiguration['components']['examples'] ?? [],
+                $rootObjectConfiguration['components']['requestBodies'] ?? [],
+                $rootObjectConfiguration['components']['headers'] ?? [],
+                $rootObjectConfiguration['components']['securitySchemes'] ?? [],
+                $rootObjectConfiguration['components']['links'] ?? [],
+                $rootObjectConfiguration['components']['callbacks'] ?? [],
+                $rootObjectConfiguration['components']['pathItems'] ?? []
             )
         );
     }

--- a/Classes/Domain/OpenApiDocumentRepository.php
+++ b/Classes/Domain/OpenApiDocumentRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sitegeist\SchemeOnYou\Domain;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Utility\Arrays;
 
 #[Flow\Scope('singleton')]
 final class OpenApiDocumentRepository
@@ -16,7 +17,7 @@ final class OpenApiDocumentRepository
     protected array $rootObjectConfiguration;
 
     /**
-     * @var array<string,array{name:string, classNames: class-string[]}>
+     * @var array<string,array{name:string, classNames: class-string[], rootObject?:array<string,mixed>}>
      */
     #[Flow\InjectConfiguration(path: 'documents')]
     protected array $documentConfiguration;
@@ -34,11 +35,17 @@ final class OpenApiDocumentRepository
 
         $documentName = $this->documentConfiguration[$name]['name'] ?? '';
         $documentClassNamePatterns = $this->documentConfiguration[$name]['classNames'];
+        $documentRootObjectConfiguration = $this->documentConfiguration[$name]['rootObject'] ?? [];
+
+        $rootObjectConfiguration = Arrays::arrayMergeRecursiveOverrule(
+            $this->rootObjectConfiguration,
+            $documentRootObjectConfiguration
+        );
 
         return $this->documentFactory->createOpenApiDocumentFromNameAndClassNamePattern(
             $documentName,
             $documentClassNamePatterns,
-            $this->rootObjectConfiguration
+            $rootObjectConfiguration
         );
     }
 }

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -13,3 +13,8 @@ roles:
       -
         privilegeTarget: 'Sitegeist.SchemeOnYou:OpenApi'
         permission: GRANT
+  'Sitegeist.SchemeOnYou:ApiSpecConsumer':
+    label: "Access to the api specs"
+    privileges:
+      - privilegeTarget: 'Sitegeist.SchemeOnYou:OpenApi'
+        permission: GRANT


### PR DESCRIPTION
Among others this allows to add security schema configuration via settings

In addition this adds the role `Sitegeist.SchemeOnYou:ApiSpecConsumer` that can be used as parent role