### PR TITLE
BUGFIX: Prevent string indexed arrays (objects) in json response instead of flat list

### DIFF
--- a/Classes/Domain/Schema/SchemaNormalizer.php
+++ b/Classes/Domain/Schema/SchemaNormalizer.php
@@ -58,12 +58,12 @@ class SchemaNormalizer
         $values = array_values(get_object_vars($value));
         if (count($values) === 1 && is_array($values[0])) {
             $reflectionParameter = $reflectionClass->getConstructor()?->getParameters()[0] ?? null;
-            return array_map(
+            return array_values(array_map(
                 fn($subvalue) => self::convertValue($subvalue, $reflectionParameter),
                 $values[0]
-            );
+            ));
         }
-        throw new \DomainException('Collections must have a single array property');
+        throw new \DomainException('Collections must have a single public array property');
     }
 
     /**


### PR DESCRIPTION
This can be the case for a value object which deliberately uses index arrays internally

```php
final readonly class CacheTagSet
{
    /**
     * Unique cache tags, indexed by their value
     * @var array<CacheTag> $items
     */
    public array $items;

    private function __construct(
        CacheTag ...$items
    ) {
        $this->items = $items;
    }

    public static function list(CacheTag ...$tags): self
    {
        $uniqueTags = [];
        foreach ($tags as $item) {
            $uniqueTags[$item->value] = $item;
        }
        return new self(...$uniqueTags);
    }

```