### PR TITLE
BUGFIX: Prevent invalid schmema by combinding `allOf` with `additionalProperties: false`

### DIFF
--- a/Classes/Domain/Schema/OpenApiSchema.php
+++ b/Classes/Domain/Schema/OpenApiSchema.php
@@ -249,6 +249,12 @@ final readonly class OpenApiSchema implements \JsonSerializable
             }
         }
 
+        if (array_key_exists(OpenApiSchemaDiscriminator::DISCRIMINATOR_NAME, $properties)) {
+            throw new \DomainException(sprintf('Object "%s" must not specify reserved property "%s".', $reflectionClass->getName(), OpenApiSchemaDiscriminator::DISCRIMINATOR_NAME), 1774439490);
+        }
+
+        $properties[OpenApiSchemaDiscriminator::DISCRIMINATOR_NAME] = self::discriminatorPropertyTypeForClassName($reflectionClass->getName());
+
         return new self(
             type: 'object',
             name: $schemaMetadata->name ?: $reflectionClass->getShortName(),
@@ -322,15 +328,17 @@ final readonly class OpenApiSchema implements \JsonSerializable
     {
         return new self(
             type: 'object',
-            properties: [
-                OpenApiSchemaDiscriminator::DISCRIMINATOR_NAME => new SchemaType(
-                    [
-                        'type' => 'string',
-                        'enum' => [str_replace('\\', '_', $className)]
-                    ]
-                )
-            ],
             required: [OpenApiSchemaDiscriminator::DISCRIMINATOR_NAME]
+        );
+    }
+
+    public static function discriminatorPropertyTypeForClassName(string $className): SchemaType
+    {
+        return new SchemaType(
+            [
+                'type' => 'string',
+                'enum' => [str_replace('\\', '_', $className)]
+            ]
         );
     }
 

--- a/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
+++ b/Tests/Unit/Domain/OpenApiDocumentFactoryTest.php
@@ -521,10 +521,15 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             type: 'object',
                             description: 'the endpoint response',
                             properties: [
+                                '__type__' => new SchemaType([
+                                    'type' => 'string',
+                                    'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointResponse']
+                                ]),
                                 'thing' => new SchemaType([
                                     'type' => 'string'
-                                ])
+                                ]),
                             ],
+                            additionalProperties: false,
                             required: [
                             'thing'
                             ]
@@ -534,10 +539,15 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             type: 'object',
                             description: 'the endpoint query',
                             properties: [
+                                '__type__' => new SchemaType([
+                                    'type' => 'string',
+                                    'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQuery']
+                                ]),
                                 'language' => new SchemaType([
                                     'type' => 'string'
                                 ])
                             ],
+                            additionalProperties: false,
                             required: [
                             'language'
                             ]
@@ -547,10 +557,15 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             type: 'object',
                             description: 'the endpoint query failure response',
                             properties: [
+                                '__type__' => new SchemaType([
+                                    'type' => 'string',
+                                    'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Path_EndpointQueryFailed']
+                                ]),
                                 'reason' => new SchemaType([
                                     'type' => 'string'
                                 ])
                             ],
+                            additionalProperties: false,
                             required: [
                             'reason'
                             ]
@@ -560,10 +575,15 @@ final class OpenApiDocumentFactoryTest extends TestCase
                             type: 'object',
                             description: 'another endpoint query',
                             properties: [
+                                '__type__' => new SchemaType([
+                                    'type' => 'string',
+                                    'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Path_AnotherEndpointQuery']
+                                ]),
                                 'pleaseFail' => new SchemaType([
                                     'type' => 'boolean'
                                 ])
                             ],
+                            additionalProperties: false,
                             required: [
                             'pleaseFail'
                             ]

--- a/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
+++ b/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
@@ -136,6 +136,10 @@ final class OpenApiSchemaTest extends TestCase
                 name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_PostalAddress',
                 description: 'see https://schema.org/PostalAddress',
                 properties: [
+                    '__type__' => new SchemaType([
+                        'type' => 'string',
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_PostalAddress']
+                    ]),
                     'streetAddress' => new SchemaType([
                         'type' => 'string',
                     ]),
@@ -170,6 +174,7 @@ final class OpenApiSchemaTest extends TestCase
                         ],
                     ]),
                 ],
+                additionalProperties: false,
                 required: [
                     'streetAddress',
                     'addressRegion',
@@ -184,6 +189,10 @@ final class OpenApiSchemaTest extends TestCase
                 name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_WeirdThing',
                 description: 'a thing composed of all primitive types',
                 properties: [
+                    '__type__' => new SchemaType([
+                        'type' => 'string',
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_WeirdThing']
+                    ]),
                     'if' => new SchemaType([
                         'type' => 'boolean',
                     ]),
@@ -205,6 +214,7 @@ final class OpenApiSchemaTest extends TestCase
                         'format' => 'duration'
                     ]),
                 ],
+                additionalProperties: false,
                 required: [
                     'if',
                     'what',
@@ -233,6 +243,10 @@ final class OpenApiSchemaTest extends TestCase
                 name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Composition',
                 description: 'a composition of types',
                 properties: [
+                    '__type__' => new SchemaType([
+                        'type' => 'string',
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Composition']
+                    ]),
                     'dayOfWeek' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_DayOfWeek'),
                     'identifier' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Identifier'),
                     'importantNumber' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_ImportantNumber'),
@@ -242,6 +256,7 @@ final class OpenApiSchemaTest extends TestCase
                     'quantitativeValue' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_QuantitativeValue'),
                     'weirdThing' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_WeirdThing'),
                 ],
+                additionalProperties: false,
                 required: [
                     'dayOfWeek',
                     'identifier',
@@ -262,6 +277,10 @@ final class OpenApiSchemaTest extends TestCase
                 name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Credentials',
                 description: 'credentials',
                 properties: [
+                    '__type__' => new SchemaType([
+                        'type' => 'string',
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Credentials']
+                    ]),
                     'username' => new SchemaType([
                         'type' => 'string',
                         'description' => 'a username'
@@ -272,6 +291,7 @@ final class OpenApiSchemaTest extends TestCase
                         'format' => 'date'
                     ]),
                 ],
+                additionalProperties: false,
                 required: [
                     'username',
                     'password',
@@ -303,11 +323,16 @@ final class OpenApiSchemaTest extends TestCase
                 name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithStuffViaInterface',
                 description: '',
                 properties: [
+                    '__type__' => new SchemaType([
+                        'type' => 'string',
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithStuffViaInterface']
+                    ]),
                     'name' => new SchemaType([
                         'type' => 'string',
                     ]),
                     'stuff' => new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_StuffInterface'),
                 ],
+                additionalProperties: false,
                 required: [
                     'name',
                     'stuff',
@@ -325,6 +350,10 @@ final class OpenApiSchemaTest extends TestCase
                 name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithStuffViaUnion',
                 description: '',
                 properties: [
+                    '__type__' => new SchemaType([
+                        'type' => 'string',
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithStuffViaUnion']
+                    ]),
                     'name' => new SchemaType([
                         'type' => 'string',
                     ]),
@@ -349,6 +378,7 @@ final class OpenApiSchemaTest extends TestCase
                         'discriminator' => new OpenApiSchemaDiscriminator(),
                     ]),
                 ],
+                additionalProperties: false,
                 required: [
                     'name',
                     'stuff',


### PR DESCRIPTION
with https://github.com/sitegeist/Sitegeist.SchemeOnYou/pull/40 we create strict objects and with https://github.com/sitegeist/Sitegeist.SchemeOnYou/pull/33 we extend objects via `__type__` as discriminator

Now these two prs create a funny state which is even explicitly documented as no-can-do:

https://json-schema.org/understanding-json-schema/reference/object#extending

`additionalProperties: false` basically prevents `__type__` to exists, but `__type__` must exist at the same point.

Now there are two ways to solve this. Either not use `allOf` to combine two schemas but inline the object. This is bad as it makes the code not explorable.

Alternatively we can safely declare `__type__` as optional property for each object and make it required via `allOf`:

```json
{
    "type": "object",
    "allOf": [
        {
            "type": "object",
            "required": [
                "__type__"
            ]
        },
        {
            "$ref": "#/components/schemas/Vendor_Site_My_Thing"
        }
    ]
}
```

```json
"Vendor_Site_My_Thing": {
    "type": "object",
    "name": "Vendor_Site_My_Thing",
    "description": "",
    "properties": {
        "text": {
            "type": "string"
        },
        "mediaType": {
            "type": "string"
        },
        "__type__": {
            "type": "string",
            "enum": [
                "Vendor_Site_My_Thing"
            ]
        }
    },
    "additionalProperties": false,
    "required": [
        "text"
    ]
}
```