### PR TITLE
FEATURE: Allow `null` in unions

### DIFF
--- a/Classes/Domain/Schema/IsSupportedInSchema.php
+++ b/Classes/Domain/Schema/IsSupportedInSchema.php
@@ -41,7 +41,9 @@ final class IsSupportedInSchema
         } elseif ($reflection instanceof \ReflectionUnionType) {
             foreach ($reflection->getTypes() as $type) {
                 if ($type instanceof \ReflectionNamedType) {
-                    if (self::isSatisfiedByReflectionType($type) === false) {
+                    if ($type->getName() === 'null') {
+                        return true;
+                    } elseif (self::isSatisfiedByReflectionType($type) === false) {
                         return false; // every part of a union has to be a named type that matched the conditions
                     }
                 } else {

--- a/Classes/Domain/Schema/SchemaType.php
+++ b/Classes/Domain/Schema/SchemaType.php
@@ -104,6 +104,9 @@ final readonly class SchemaType implements \JsonSerializable
                 );
             }
             $reflectionTypeName = $reflectionType->getName();
+            if ($reflectionTypeName === 'null') {
+                continue;
+            }
             if (class_exists($reflectionTypeName) || enum_exists($reflectionTypeName)) {
                 $subschemas[] = new OpenApiSchema(
                     type: 'object',
@@ -118,13 +121,6 @@ final readonly class SchemaType implements \JsonSerializable
                     1709560367
                 );
             }
-        }
-
-        if ($reflectionUnionType->allowsNull()) {
-            throw new \DomainException(
-                'nullable types are not supported in unions yet',
-                1709560368
-            );
         }
 
         return new self([

--- a/Classes/Domain/Schema/SchemaType.php
+++ b/Classes/Domain/Schema/SchemaType.php
@@ -105,6 +105,9 @@ final readonly class SchemaType implements \JsonSerializable
             }
             $reflectionTypeName = $reflectionType->getName();
             if ($reflectionTypeName === 'null') {
+                $subschemas[] = new OpenApiSchema(
+                    type: 'null'
+                );
                 continue;
             }
             if (class_exists($reflectionTypeName) || enum_exists($reflectionTypeName)) {

--- a/Tests/Fixtures/Stuff/ClassWithNullableStuff.php
+++ b/Tests/Fixtures/Stuff/ClassWithNullableStuff.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+readonly class ClassWithNullableStuff
+{
+    public function __construct(
+        public ?string $name,
+        public ?BoringStuff $stuff
+    ) {
+    }
+}

--- a/Tests/Fixtures/Stuff/ClassWithNullableStuffViaUnion.php
+++ b/Tests/Fixtures/Stuff/ClassWithNullableStuffViaUnion.php
@@ -7,7 +7,7 @@ namespace Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff;
 use Neos\Flow\Annotations as Flow;
 
 #[Flow\Proxy(false)]
-readonly class ClassWithStuffViaOptionalUnion
+readonly class ClassWithNullableStuffViaUnion
 {
     public function __construct(
         public BoringStuff|InterestingStuff|null $stuff

--- a/Tests/Fixtures/Stuff/ClassWithStuffViaOptionalUnion.php
+++ b/Tests/Fixtures/Stuff/ClassWithStuffViaOptionalUnion.php
@@ -10,7 +10,7 @@ use Neos\Flow\Annotations as Flow;
 readonly class ClassWithStuffViaOptionalUnion
 {
     public function __construct(
-        public BoringStuff|InterestingStuff|null $stuff = null
+        public BoringStuff|InterestingStuff|null $stuff
     ) {
     }
 }

--- a/Tests/Fixtures/Stuff/ClassWithStuffViaOptionalUnion.php
+++ b/Tests/Fixtures/Stuff/ClassWithStuffViaOptionalUnion.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+readonly class ClassWithStuffViaOptionalUnion
+{
+    public function __construct(
+        public BoringStuff|InterestingStuff|null $stuff = null
+    ) {
+    }
+}

--- a/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
+++ b/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
@@ -95,6 +95,14 @@ final class DtoSpecificationTest extends TestCase
             'isSVDTO' => false,
         ];
 
+        yield Fixtures\Stuff\ClassWithNullableStuff::class => [
+            'typeName' => Fixtures\Stuff\ClassWithNullableStuff::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
         yield Fixtures\Stuff\CollectionOfStuffViaInterface::class => [
             'typeName' => Fixtures\Stuff\CollectionOfStuffViaInterface::class,
             'isSupported' => true,

--- a/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
+++ b/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
@@ -127,6 +127,14 @@ final class DtoSpecificationTest extends TestCase
             'isSVDTO' => false,
         ];
 
+        yield Fixtures\Stuff\ClassWithStuffViaOptionalUnion::class => [
+            'typeName' => Fixtures\Stuff\ClassWithStuffViaOptionalUnion::class,
+            'isSupported' => true,
+            'isDTO' => true,
+            'isDTC' => false,
+            'isSVDTO' => false,
+        ];
+
         // invalid collections
 
         yield Fixtures\InvalidObjects\CollectionWithTooManyConstructorArguments::class => [

--- a/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
+++ b/Tests/Unit/Domain/Schema/DtoSpecificationTest.php
@@ -127,8 +127,8 @@ final class DtoSpecificationTest extends TestCase
             'isSVDTO' => false,
         ];
 
-        yield Fixtures\Stuff\ClassWithStuffViaOptionalUnion::class => [
-            'typeName' => Fixtures\Stuff\ClassWithStuffViaOptionalUnion::class,
+        yield Fixtures\Stuff\ClassWithNullableStuffViaUnion::class => [
+            'typeName' => Fixtures\Stuff\ClassWithNullableStuffViaUnion::class,
             'isSupported' => true,
             'isDTO' => true,
             'isDTC' => false,

--- a/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
+++ b/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
@@ -24,6 +24,7 @@ use Sitegeist\SchemeOnYou\Tests\Fixtures\PostalAddress;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\PostalAddressCollection;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\QuantitativeValue;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\BoringStuff;
+use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithNullableStuff;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithStuffViaInterface;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithNullableStuffViaUnion;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithStuffViaUnion;
@@ -352,6 +353,41 @@ final class OpenApiSchemaTest extends TestCase
                     'name',
                     'stuff',
                 ]
+            )
+        ];
+
+        yield 'ClassWithNullableStuff' => [
+            'className' => ClassWithNullableStuff::class,
+            'expectedDefinition' => new OpenApiSchema(
+                type: 'object',
+                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithNullableStuff',
+                description: '',
+                properties: [
+                    '__type__' => new SchemaType([
+                        'type' => 'string',
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithNullableStuff']
+                    ]),
+                    'stuff' => new SchemaType([
+                        'oneOf' => [
+                            new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_BoringStuff'),
+                            [
+                                'type' => 'null'
+                            ]
+                        ]
+                    ]),
+                    'name' => new SchemaType([
+                        'oneOf' => [
+                            [
+                                'type' => 'string'
+                            ],
+                            [
+                                'type' => 'null'
+                            ]
+                        ]
+                    ])
+                ],
+                additionalProperties: false,
+                required: ['name', 'stuff']
             )
         ];
 

--- a/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
+++ b/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
@@ -382,13 +382,16 @@ final class OpenApiSchemaTest extends TestCase
                                     OpenApiSchema::discriminatorForClassName(InterestingStuff::class),
                                     new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_InterestingStuff'),
                                 )
+                            ),
+                            new OpenApiSchema(
+                                type: 'null'
                             )
                         ),
                         'discriminator' => new OpenApiSchemaDiscriminator(),
                     ]),
                 ],
                 additionalProperties: false,
-                required: []
+                required: ['stuff']
             )
         ];
     }

--- a/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
+++ b/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
@@ -25,7 +25,7 @@ use Sitegeist\SchemeOnYou\Tests\Fixtures\PostalAddressCollection;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\QuantitativeValue;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\BoringStuff;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithStuffViaInterface;
-use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithStuffViaOptionalUnion;
+use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithNullableStuffViaUnion;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithStuffViaUnion;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\InterestingStuff;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\StuffInterface;
@@ -355,16 +355,16 @@ final class OpenApiSchemaTest extends TestCase
             )
         ];
 
-        yield 'ClassWithStuffViaOptionalUnion' => [
-            'className' => ClassWithStuffViaOptionalUnion::class,
+        yield 'ClassWithNullableStuffViaUnion' => [
+            'className' => ClassWithNullableStuffViaUnion::class,
             'expectedDefinition' => new OpenApiSchema(
                 type: 'object',
-                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithStuffViaOptionalUnion',
+                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithNullableStuffViaUnion',
                 description: '',
                 properties: [
                     '__type__' => new SchemaType([
                         'type' => 'string',
-                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithStuffViaOptionalUnion']
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithNullableStuffViaUnion']
                     ]),
                     'stuff' => new SchemaType([
                         'type' => 'object',

--- a/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
+++ b/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
@@ -8,7 +8,6 @@ use Neos\Flow\Annotations as Flow;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Sitegeist\SchemeOnYou\Domain\Schema\OpenApiReference;
-use Sitegeist\SchemeOnYou\Domain\Schema\OpenApiOneOfCollection;
 use Sitegeist\SchemeOnYou\Domain\Schema\OpenApiSchema;
 use Sitegeist\SchemeOnYou\Domain\Schema\OpenApiSchemaDiscriminator;
 use Sitegeist\SchemeOnYou\Domain\Schema\OpenApiSchemaOrReferenceCollection;
@@ -26,10 +25,10 @@ use Sitegeist\SchemeOnYou\Tests\Fixtures\PostalAddressCollection;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\QuantitativeValue;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\BoringStuff;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithStuffViaInterface;
+use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithStuffViaOptionalUnion;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\ClassWithStuffViaUnion;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\InterestingStuff;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\StuffInterface;
-use Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff\WeirdStuff;
 use Sitegeist\SchemeOnYou\Tests\Fixtures\WeirdThing;
 
 #[Flow\Proxy(false)]
@@ -353,6 +352,43 @@ final class OpenApiSchemaTest extends TestCase
                     'name',
                     'stuff',
                 ]
+            )
+        ];
+
+        yield 'ClassWithStuffViaOptionalUnion' => [
+            'className' => ClassWithStuffViaOptionalUnion::class,
+            'expectedDefinition' => new OpenApiSchema(
+                type: 'object',
+                name: 'Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithStuffViaOptionalUnion',
+                description: '',
+                properties: [
+                    '__type__' => new SchemaType([
+                        'type' => 'string',
+                        'enum' => ['Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_ClassWithStuffViaOptionalUnion']
+                    ]),
+                    'stuff' => new SchemaType([
+                        'type' => 'object',
+                        'oneOf' => new OpenApiSchemaOrReferenceCollection(
+                            new OpenApiSchema(
+                                type: 'object',
+                                allOf: new OpenApiSchemaOrReferenceCollection(
+                                    OpenApiSchema::discriminatorForClassName(BoringStuff::class),
+                                    new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_BoringStuff'),
+                                )
+                            ),
+                            new OpenApiSchema(
+                                type: 'object',
+                                allOf: new OpenApiSchemaOrReferenceCollection(
+                                    OpenApiSchema::discriminatorForClassName(InterestingStuff::class),
+                                    new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_InterestingStuff'),
+                                )
+                            )
+                        ),
+                        'discriminator' => new OpenApiSchemaDiscriminator(),
+                    ]),
+                ],
+                additionalProperties: false,
+                required: []
             )
         ];
     }


### PR DESCRIPTION
It is to be discussed how optionals are handled when creating the open api schema. My assumption was a property is optional if it can accept `null` as value. BUT we create the schema as optional if there is a default value. These are two different things and the current definition allows clients to expect a value still even if there is `null`. Ill tackle this in another pr.

Edit we use `oneOf` with `{ "type": "null" }` to make properties optional while these are still `required`. So generally ALL properties are at all times required but might be null. And if they have a default value they are optional?