### PR TITLE
BUGFIX: Unions of objects with schema name

### DIFF
--- a/Classes/Domain/Schema/OpenApiReference.php
+++ b/Classes/Domain/Schema/OpenApiReference.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sitegeist\SchemeOnYou\Domain\Schema;
 
 use Neos\Flow\Annotations as Flow;
+use Sitegeist\SchemeOnYou\Domain\Metadata\Schema as SchemaMetadata;
 
 /**
  * @see https://swagger.io/specification/#reference-object
@@ -17,9 +18,15 @@ final readonly class OpenApiReference implements \JsonSerializable
     ) {
     }
 
+    /**
+     * @param class-string $className
+     */
     public static function fromClassName(string $className): self
     {
-        return new self('#/components/schemas/' . str_replace('\\', '_', $className));
+        $reflectionClass = new \ReflectionClass($className);
+        $definitionMetadata = SchemaMetadata::fromReflectionClass($reflectionClass);
+
+        return new self('#/components/schemas/' . $definitionMetadata->name);
     }
 
     public function getName(): string

--- a/Tests/Fixtures/Stuff/InterestingStuff.php
+++ b/Tests/Fixtures/Stuff/InterestingStuff.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Sitegeist\SchemeOnYou\Tests\Fixtures\Stuff;
 
 use Neos\Flow\Annotations as Flow;
+use Sitegeist\SchemeOnYou\Domain\Metadata as OpenApi;
 
 #[Flow\Proxy(false)]
+#[OpenApi\Schema('', name: 'Interesting Stuff')]
 readonly class InterestingStuff implements StuffInterface
 {
     public function __construct(

--- a/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
+++ b/Tests/Unit/Domain/Schema/OpenApiSchemaTest.php
@@ -342,7 +342,7 @@ final class OpenApiSchemaTest extends TestCase
                                 type: 'object',
                                 allOf: new OpenApiSchemaOrReferenceCollection(
                                     OpenApiSchema::discriminatorForClassName(InterestingStuff::class),
-                                    new OpenApiReference('#/components/schemas/Sitegeist_SchemeOnYou_Tests_Fixtures_Stuff_InterestingStuff'),
+                                    new OpenApiReference('#/components/schemas/Interesting Stuff'),
                                 )
                             )
                         ),


### PR DESCRIPTION
Defining `#[OpenApi\Schema('', name: 'Interesting Stuff')]` makes the object available at

```
components.schemas {
   "Interesting Stuff": {
       "type": "object",
       "name": "Interesting Stuff",
       // ...
   },
}
```

we cannot reference it via class name underscore syntax